### PR TITLE
added headers option - work in progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,17 @@ CTRL-D.
 
 ### Sending authentication headers for Meshblu (formerly SkyNet.im)
 
-Meshblu uses skynet_auth_uuid and skynet_auth_token authentication headers in all HTTP and CoAP API calls. You can test Meshblu CoAP API calls by adding: 
+Meshblu uses skynet_auth_uuid/meshblu_auth_uuid and skynet_auth_token/meshblu_auth_token authentication headers in all HTTP and CoAP API calls. You can test Meshblu CoAP API calls by adding: 
 
 -H "skynet_auth_uuid={:UUID}&skynet_auth_token={:TOKEN}" to your CoAP CLI call like this:
 
 coap post -p "payload=hi&devices=9314f1d1-2404-11e4-a3a9-9b953437ccb1" -H "skynet_auth_uuid=9fb3cb71-23e9-11e4-a870-9f04ce09bb6b&skynet_auth_token=9fv55f6hi0iicnmii8k4rrs4t4g9cnmi" coap://coap.meshblu.com/messages
+
+or:
+
+-H "meshblu_auth_uuid={:UUID}&meshblu_auth_token={:TOKEN}" to your CoAP CLI call like this:
+
+coap post -p "payload=hi&devices=9314f1d1-2404-11e4-a3a9-9b953437ccb1" -H "meshblu_auth_uuid=9fb3cb71-23e9-11e4-a870-9f04ce09bb6b&meshblu_auth_token=9fv55f6hi0iicnmii8k4rrs4t4g9cnmi" coap://coap.meshblu.com/messages
 
 License
 ----------------------------

--- a/index.js
+++ b/index.js
@@ -73,17 +73,17 @@ var toString = function(value) {
 
 if (method === 'GET' || method === 'DELETE' || program.payload) {
   if(program.headers){
-    // Parse string of headers looking for skynet uuid/tokens and send them in mesage
+    // Parse string of headers looking for skynet/meshblu uuid/tokens and send them in mesage
     var query = {};
     var a = program.headers.split('&');
     for (var i in a)
     {
       var b = a[i].split('=');
 
-      if (decodeURIComponent(b[0]) == "skynet_auth_uuid"){
+      if (decodeURIComponent(b[0]) == "skynet_auth_uuid" || decodeURIComponent(b[0]) == "meshblu_auth_uuid"){
         req.setOption('98', new Buffer(decodeURIComponent(b[1])));
       } 
-      if (decodeURIComponent(b[0]) == "skynet_auth_token"){
+      if (decodeURIComponent(b[0]) == "skynet_auth_token" || decodeURIComponent(b[0]) == "meshblu_auth_token"){
         req.setOption('99', new Buffer(decodeURIComponent(b[1])));
       } 
     }    


### PR DESCRIPTION
I'm trying to add headers support to coap-cli.  I was thinking that it could be similar to payload i.e.

coap get -h "skynet_auth_uuid=123&skynet_auth_token=abc" coap://coap.octoblu.com/status

The -h headers option has been added as well as the parsing logic but I am having trouble actually sending the headers with the coap call.  Here is the line(s) in question.

https://github.com/chrismatthieu/coap-cli/blob/master/index.js#L75

Please let me know if you spot my issue(s).

Thanks,
Chris
