### PR TITLE
chore: use Node 12, 14, and 16 for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "8"
-  - "10"
-  - "11"
   - "12"
+  - "14"
+  - "16"


### PR DESCRIPTION
This PR updates the node versions used in the CI. It should get rid of some problems that occur in the CI – however, as the tests currently fail because of breaking changes in `commander` (#122), the CI will probably stay red. This is one step towards a working CI, though.

As a next step it could probably be considered to move to GitHub Actions.