### PR TITLE
fix: remove brackets from literal IPv6 addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,12 @@ if (url.protocol !== 'coap:' || !url.hostname) {
   process.exit(-1)
 }
 
+const hostname = url.hostname
+// Remove brackets from literal IPv6 addresses
+if (hostname.startsWith('[') && hostname.endsWith(']')) {
+  url.hostname = hostname.substring(1, hostname.length - 1)
+}
+
 coap.parameters.exchangeLifetime = program.timeout ? program.timeout : 30
 
 if (program.block2 && (program.block2 < 1 || program.block2 > 6)) {


### PR DESCRIPTION
This PR should fix #56 by removing the square brackets from literal IPv6 addresses given as an input. As the tests are currently failing it might be better to merge this PR after #125 and also after another test has been added for ensuring that the CLI actually works now with IPv6 addresses.