### PR TITLE
fix: allow use of POST and PUT without payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,5 +127,5 @@ req.on('response', function (res) {
 if (method === 'GET' || method === 'DELETE' || program.opts().payload) {
   req.end(program.opts().payload)
 } else {
-  process.stdin.pipe(req)
+  process.stdin.pipe(req.end())
 }


### PR DESCRIPTION
This PR fixes a bug that has been pointed out by @citrullin: So far it wasn't possible to use a POST or PUT request that didn't have a payload because the request's `end()` method wasn't called. With the now added method this problem is solved :)