### PR TITLE
fix: resolve issue with POST/PUT from stdin

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,8 @@ req.on('response', function (res) {
 
 if (method === 'GET' || method === 'DELETE' || program.opts().payload) {
   req.end(program.opts().payload)
+} else if (!process.stdin.isTTY) {
+  process.stdin.pipe(req)
 } else {
-  process.stdin.pipe(req.end())
+  req.end()
 }


### PR DESCRIPTION
This PR should solve the issue that has been introduced by #129 by distinguishing between commands that use stdin and those that don't. However, this probably won't make it possible to use `coap post coap://example.org` followed by input on the command line (ended with a `CTRL + D`) anymore. I'd assume that the new behavior should be more intuitive to use, though.

For some reason, I haven't been able to add a working test for the fix to `test.js`. Using it manually from the command line works, though.